### PR TITLE
Update CampaignCategory.php

### DIFF
--- a/src/Model/CampaignCategory.php
+++ b/src/Model/CampaignCategory.php
@@ -64,7 +64,7 @@ class CampaignCategory
      */
     public function getCategories()
     {
-        return $this->categories;
+        return $this->categories ?? [];
     }
 
     /**

--- a/src/Model/CampaignCategory.php
+++ b/src/Model/CampaignCategory.php
@@ -62,7 +62,7 @@ class CampaignCategory
     /**
      * @return CampaignCategory[]
      */
-    public function getCategories(): array
+    public function getCategories()
     {
         return $this->categories;
     }

--- a/src/Model/CampaignCategory.php
+++ b/src/Model/CampaignCategory.php
@@ -62,7 +62,7 @@ class CampaignCategory
     /**
      * @return CampaignCategory[]
      */
-    public function getCategories()
+    public function getCategories(): array
     {
         return $this->categories ?? [];
     }


### PR DESCRIPTION
Removed array typecast on getCategories. If a category has no sub categories we where getting errors like this:
Symfony\Component\Debug\Exception\FatalThrowableError: Return value of Hypeit\TradeTracker\Model\CampaignCategory::getCategories() must be of the type array, null returned