### PR TITLE
Add Timezone to CampaignInfo

### DIFF
--- a/src/Mapper/CampaignInfoMapper.php
+++ b/src/Mapper/CampaignInfoMapper.php
@@ -74,6 +74,8 @@ class CampaignInfoMapper implements MapperInterface
         $campaignInfo->setAttributionModelSales(
             (new CampaignAttributionModelMapper())->hydrate($value->attributionModelSales)
         );
+        
+        $campaignInfo->setTimezone($value->timeZone);
 
         return $campaignInfo;
     }

--- a/src/Model/CampaignInfo.php
+++ b/src/Model/CampaignInfo.php
@@ -128,6 +128,27 @@ class CampaignInfo
      * @var CampaignAttributionModel
      */
     private $attributionModelSales;
+    
+    /**
+     * @var string|null
+     */
+    private $timeZone;
+
+    /**
+     * @return string|null
+     */
+    public function getTimeZone(): ?string
+    {
+        return $this->timeZone;
+    }
+
+    /**
+     * @param string|null $timeZone
+     */
+    public function setTimeZone(?string $timeZone): void
+    {
+        $this->timeZone = $timeZone;
+    }
 
     /**
      * @return CampaignCategory


### PR DESCRIPTION
This pull request adds timeZone to the CampaignInfo model.

Ref: https://ws.tradetracker.com/soap/affiliate?wsdl

@stixx 