### PR TITLE
prevent unnecessary usage of getAffiliateSites method

### DIFF
--- a/src/Client/TradeTrackerClient.php
+++ b/src/Client/TradeTrackerClient.php
@@ -410,13 +410,13 @@ class TradeTrackerClient
      *
      * @param \DateTime $startDate The start date of the transactions.
      * @param \DateTime $endDate   The end date of the transactions.
+     * @param Model\AffiliateSite[] $affiliateSites Affiliate site array. Can be obtained with getAffiliateSites() method
      *
      * @return array
      */
-    public function getTransactions(\DateTime $startDate, \DateTime $endDate)
+    public function getTransactions(\DateTime $startDate, \DateTime $endDate, array $affiliateSites)
     {
         $data = [];
-        $affiliateSites = $this->getAffiliateSites();
 
         $filter = new Filter\ConversionTransactionFilter();
         $filter->setRegistrationDateFrom($startDate->format('Y-m-d'));

--- a/src/Client/TradeTrackerClient.php
+++ b/src/Client/TradeTrackerClient.php
@@ -414,9 +414,13 @@ class TradeTrackerClient
      *
      * @return array
      */
-    public function getTransactions(\DateTime $startDate, \DateTime $endDate, array $affiliateSites)
+    public function getTransactions(\DateTime $startDate, \DateTime $endDate, array $affiliateSites = [])
     {
         $data = [];
+        
+        if (empty($affiliateSites)) {
+            $affiliateSites = $this->getAffiliateSites();
+        }
 
         $filter = new Filter\ConversionTransactionFilter();
         $filter->setRegistrationDateFrom($startDate->format('Y-m-d'));


### PR DESCRIPTION
Hello @lvdhoorn @stixx ,

 I changed getTransactions method to accept affiliateSites array to prevent multiple call to getAffiliateSites endpoint while processing multiple dates.

 Motivation for this change is recent change on Tradetracker API and rate limit for this endpoint. It is being exhausted easily.
 
Change is also backward compatible thanks to default value of the new parameter.